### PR TITLE
Add category to library.properties

### DIFF
--- a/arduino/LM73/library.properties
+++ b/arduino/LM73/library.properties
@@ -3,6 +3,7 @@ author=Zak Kemble
 email=contact@zakkemble.co.uk
 sentence=LM73 Temperature Sensor Library
 paragraph=
+category=Sensors
 url=https://github.com/zkemble/LM73
 architectures=avr
 version=1.0


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library LM73 is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6 and 1.6.7. If you disagree with my category choice I'm happy to change the category to any of the other [valid category values](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.
